### PR TITLE
refactor: simplify broiler listing output

### DIFF
--- a/OmniAPI/Controllers/FarmController.cs
+++ b/OmniAPI/Controllers/FarmController.cs
@@ -14,6 +14,15 @@ using OmniAPI.Classes;
 
 namespace OmniAPI.Controllers
 {
+    public class BroilerDto
+    {
+        public int ID { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public int? farmID { get; set; }
+        public int? NoOfBirds { get; set; }
+    }
+
     [EnableCors(origins: "*", headers: "*", methods: "*")]
     public class FarmController : ApiController
     {
@@ -366,14 +375,21 @@ namespace OmniAPI.Controllers
 
         [Route("getAllBroilers")]
         [HttpGet]
-        public List<tbl_Briolers> getAllBroilers()
+        public List<BroilerDto> getAllBroilers()
         {
             try
             {
                 omnioEntities en = new omnioEntities();
                 en.Configuration.LazyLoadingEnabled = false;
 
-                return en.tbl_Briolers.ToList();
+                return en.tbl_Briolers.Select(x => new BroilerDto
+                {
+                    ID = x.ID,
+                    Name = x.Name,
+                    Description = x.Description,
+                    farmID = x.farmID,
+                    NoOfBirds = x.NoOfBirds
+                }).ToList();
             }
             catch
             {


### PR DESCRIPTION
## Summary
- avoid returning related collections in getAllBroilers by projecting to a lightweight DTO
- add BroilerDto to represent broiler fields returned by API

## Testing
- ⚠️ `dotnet build OmniAPI.sln` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a71a77f483248adb01230e7cb37e