### PR TITLE
Add getMortalities endpoint for broiler data

### DIFF
--- a/OmniAPI/Controllers/FarmController.cs
+++ b/OmniAPI/Controllers/FarmController.cs
@@ -572,6 +572,23 @@ namespace OmniAPI.Controllers
             }
         }
 
+        [Route("getMortalities/{broilerid}")]
+        [HttpGet]
+        public List<tbl_BriolerData> getMortalities(int broilerid)
+        {
+            try
+            {
+                omnioEntities en = new omnioEntities();
+                en.Configuration.LazyLoadingEnabled = false;
+
+                return en.tbl_BriolerData.Where(x => x.briolerID == broilerid).ToList();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
 
 
         [Route("sendMail/{id}")]


### PR DESCRIPTION
## Summary
- add `getMortalities/{broilerid}` route to retrieve `tbl_BriolerData` entries for a broiler

## Testing
- `dotnet build OmniAPI.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c00a0fa08c8324ae319353cb8736af