### PR TITLE
Add removeMortalities endpoint to DashController

### DIFF
--- a/OmniAPI/Controllers/DashController.cs
+++ b/OmniAPI/Controllers/DashController.cs
@@ -204,6 +204,28 @@ namespace OmniAPI.Controllers
             }
         }
 
+        [Route("removeMortalities")]
+        [HttpPost]
+        // [Authorize]
+        public bool removeMortalities(tbl_BriolerData data)
+        {
+            try
+            {
+                Encryption ecn = new Encryption();
+
+                omnioEntities en = new omnioEntities();
+                tbl_BriolerData d = en.tbl_BriolerData.Find(data.ID);
+                en.tbl_BriolerData.Remove(d);
+                en.SaveChanges();
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
 
         [Route("getFatalitiesDay")]
         [HttpPost]


### PR DESCRIPTION
## Summary
- add removeMortalities API endpoint to DashController

## Testing
- `dotnet build OmniAPI.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c04de040548324b9a544036daa7204