### PR TITLE
feat: add updateWeights endpoint

### DIFF
--- a/OmniAPI/Controllers/DashController.cs
+++ b/OmniAPI/Controllers/DashController.cs
@@ -287,7 +287,7 @@ namespace OmniAPI.Controllers
         {
             try
             {
-               
+
                 Encryption ecn = new Encryption();
 
                 //  Weights.dateTime = Weights.dateTime.Value.ToLocalTime();
@@ -312,6 +312,52 @@ namespace OmniAPI.Controllers
                 return Weights;
             }
             catch(Exception e)
+            {
+                string ex = e.ToString();
+                return null;
+            }
+        }
+
+        [Route("updateWeights")]
+        [HttpPost]
+        // [Authorize]
+        public tbl_Weights updateWeights(tbl_Weights Weights)
+        {
+            try
+            {
+
+                Encryption ecn = new Encryption();
+
+                var readings = new double?[]
+                {
+                    Weights.WeightBack,
+                    Weights.WeightCenter,
+                    Weights.WeightFront,
+                    Weights.WeightBackR,
+                    Weights.WeightCenterR,
+                    Weights.WeightFrontR
+                };
+
+                double total = readings.Where(r => r.HasValue).Sum(r => r.Value);
+                int count = readings.Count(r => r.HasValue);
+                double? sampleSize = Weights.SampleSize;
+
+                if (sampleSize.HasValue && sampleSize.Value > 0 && count > 0)
+                    Weights.WeightAverage = Math.Round(total / count / sampleSize.Value, 3);
+                else
+                    Weights.WeightAverage = null;
+
+                omnioEntities en = new omnioEntities();
+                if (Weights.ID > 0)
+                    en.tbl_Weights.AddOrUpdate(Weights);
+                else
+                    en.tbl_Weights.Add(Weights);
+
+                en.SaveChanges();
+
+                return Weights;
+            }
+            catch (Exception e)
             {
                 string ex = e.ToString();
                 return null;


### PR DESCRIPTION
## Summary
- add `/updateWeights` API to create or modify broiler weight records
- compute average weight from provided readings and sample size, ignoring null values
- preserve null weight inputs and insert new rows when no ID is supplied

## Testing
- `dotnet build OmniAPI.sln` *(fails: command not found: dotnet)*
- `msbuild OmniAPI.sln` *(fails: command not found: msbuild)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.1.99 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68c1d65230b48324930a63e6d624bab9