### PR TITLE
Support cycle ID when updating broiler weights

### DIFF
--- a/OmniAPI/Omnio.edmx
+++ b/OmniAPI/Omnio.edmx
@@ -383,6 +383,7 @@
           </Key>
           <Property Name="ID" Type="bigint" StoreGeneratedPattern="Identity" Nullable="false" />
           <Property Name="BroilerID" Type="int" />
+          <Property Name="cycleId" Type="int" />
           <Property Name="WeightBack" Type="float" />
           <Property Name="WeightCenter" Type="float" />
           <Property Name="WeightFront" Type="float" />
@@ -1168,6 +1169,7 @@ FROM [dbo].[vw_DeviceDetails] AS [vw_DeviceDetails]</DefiningQuery>
           </Key>
           <Property Name="ID" Type="Int64" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
           <Property Name="BroilerID" Type="Int32" />
+          <Property Name="cycleId" Type="Int32" />
           <Property Name="WeightBack" Type="Double" />
           <Property Name="WeightCenter" Type="Double" />
           <Property Name="WeightFront" Type="Double" />
@@ -1859,6 +1861,7 @@ FROM [dbo].[vw_DeviceDetails] AS [vw_DeviceDetails]</DefiningQuery>
                 <ScalarProperty Name="WeightCenter" ColumnName="WeightCenter" />
                 <ScalarProperty Name="WeightBack" ColumnName="WeightBack" />
                 <ScalarProperty Name="BroilerID" ColumnName="BroilerID" />
+                <ScalarProperty Name="cycleId" ColumnName="cycleId" />
                 <ScalarProperty Name="ID" ColumnName="ID" />
               </MappingFragment>
             </EntityTypeMapping>

--- a/OmniAPI/tbl_Weights.cs
+++ b/OmniAPI/tbl_Weights.cs
@@ -16,6 +16,7 @@ namespace OmniAPI
     {
         public long ID { get; set; }
         public Nullable<int> BroilerID { get; set; }
+        public Nullable<int> cycleId { get; set; }
         public Nullable<double> WeightBack { get; set; }
         public Nullable<double> WeightCenter { get; set; }
         public Nullable<double> WeightFront { get; set; }


### PR DESCRIPTION
## Summary
- add `cycleId` field to weight entity so updateWeights API records the cycle
- map new `cycleId` column in Entity Framework model

## Testing
- `dotnet build OmniAPI.sln` *(fails: command not found)*
- `msbuild OmniAPI.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cfb9fa1c83248c0681090b431826