### PR TITLE
Add cycleId support for placement weights

### DIFF
--- a/OmniAPI/Controllers/BroilerController.cs
+++ b/OmniAPI/Controllers/BroilerController.cs
@@ -518,15 +518,28 @@ namespace OmniAPI.Controllers
 
         [Route("updateWeight")]
         [HttpPost]
-        public bool updateWeight(tbl_PlacementWeight weight)
+        public bool updateWeight(PlacementWeightDto weight)
         {
             try
             {
-              //  double calcboxes = weight.noOfBirdsPerBox.Value * weight.averageBox.Value;
-                double bird = (weight.totalBirdWeight.Value ) / weight.noOfBirdsPerBox.Value;
+                double bird = (weight.totalBirdWeight.Value) / weight.noOfBirdsPerBox.Value;
+                int boxes = Convert.ToInt32(bird);
                 omnioEntities en = new omnioEntities();
 
-                en.tbl_PlacementWeight.AddOrUpdate(weight);             
+                var entity = new tbl_PlacementWeight
+                {
+                    id = weight.id,
+                    totalBirdWeight = weight.totalBirdWeight,
+                    averageBox = weight.averageBox,
+                    noOfBoxes = boxes,
+                    noOfBirdsPerBox = weight.noOfBirdsPerBox,
+                    date = weight.date,
+                    broilerId = weight.facilityId,
+                    cycleId = weight.cycleId,
+                    weightId = weight.weightId
+                };
+
+                en.tbl_PlacementWeight.AddOrUpdate(entity);
 
                 en.SaveChanges();
                 return true;

--- a/OmniAPI/OmniAPI.csproj
+++ b/OmniAPI/OmniAPI.csproj
@@ -243,6 +243,7 @@
     <Compile Include="Areas\HelpPage\XmlDocumentationProvider.cs" />
     <Compile Include="Classes\Encryption.cs" />
     <Compile Include="FarmDto.cs" />
+    <Compile Include="PlacementWeightDto.cs" />
     <Compile Include="Controllers\BroilerController.cs" />
     <Compile Include="Controllers\DashController.cs" />
     <Compile Include="Controllers\DeviceController.cs" />

--- a/OmniAPI/Omnio.edmx
+++ b/OmniAPI/Omnio.edmx
@@ -314,6 +314,7 @@
           <Property Name="noOfBirdsPerBox" Type="int" />
           <Property Name="date" Type="datetime" />
           <Property Name="broilerId" Type="int" />
+          <Property Name="cycleId" Type="int" />
           <Property Name="weightId" Type="bigint" />
         </EntityType>
         <EntityType Name="tbl_Systems">
@@ -1461,6 +1462,7 @@ FROM [dbo].[vw_DeviceDetails] AS [vw_DeviceDetails]</DefiningQuery>
           <Property Name="noOfBirdsPerBox" Type="Int32" />
           <Property Name="date" Type="DateTime" Precision="3" />
           <Property Name="broilerId" Type="Int32" />
+          <Property Name="cycleId" Type="Int32" />
           <Property Name="weightId" Type="Int64" />
         </EntityType>
         <EntityType Name="tbl_BroilerSettings">
@@ -1928,6 +1930,7 @@ FROM [dbo].[vw_DeviceDetails] AS [vw_DeviceDetails]</DefiningQuery>
             <EntityTypeMapping TypeName="omnioModel.tbl_PlacementWeight">
               <MappingFragment StoreEntitySet="tbl_PlacementWeight">
                 <ScalarProperty Name="weightId" ColumnName="weightId" />
+                <ScalarProperty Name="cycleId" ColumnName="cycleId" />
                 <ScalarProperty Name="broilerId" ColumnName="broilerId" />
                 <ScalarProperty Name="date" ColumnName="date" />
                 <ScalarProperty Name="noOfBirdsPerBox" ColumnName="noOfBirdsPerBox" />

--- a/OmniAPI/PlacementWeightDto.cs
+++ b/OmniAPI/PlacementWeightDto.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace OmniAPI
+{
+    public class PlacementWeightDto
+    {
+        public int id { get; set; }
+        public int facilityId { get; set; }
+        public int cycleId { get; set; }
+        public double? totalBirdWeight { get; set; }
+        public double? averageBox { get; set; }
+        public int? noOfBirdsPerBox { get; set; }
+        public DateTime? date { get; set; }
+        public long? weightId { get; set; }
+    }
+}

--- a/OmniAPI/tbl_PlacementWeight.cs
+++ b/OmniAPI/tbl_PlacementWeight.cs
@@ -21,6 +21,7 @@ namespace OmniAPI
         public Nullable<int> noOfBirdsPerBox { get; set; }
         public Nullable<System.DateTime> date { get; set; }
         public Nullable<int> broilerId { get; set; }
+        public Nullable<int> cycleId { get; set; }
         public Nullable<long> weightId { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- Accept facility and cycle IDs when updating placement weights
- Map facilityId to broilerId and persist cycleId in placement weight records
- Include PlacementWeightDto in project build

## Testing
- `dotnet build OmniAPI.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fc045f60832490394cb677ec9282