### PR TITLE
Handle cycleId in updateMortalities endpoint

### DIFF
--- a/OmniAPI/Controllers/DashController.cs
+++ b/OmniAPI/Controllers/DashController.cs
@@ -158,6 +158,7 @@ namespace OmniAPI.Controllers
                         existing.fatalities = data.fatalities;
                         existing.dateTime = data.dateTime;
                         existing.culls = data.culls;
+                        existing.cycleId = data.cycleId;
                         existing.eventCullsID = data.eventCullsID;
                         existing.eventMortalitiesID = data.eventMortalitiesID;
                     }

--- a/OmniAPI/Omnio.edmx
+++ b/OmniAPI/Omnio.edmx
@@ -37,6 +37,7 @@
           </Key>
           <Property Name="ID" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
           <Property Name="briolerID" Type="int" />
+          <Property Name="cycleId" Type="int" />
           <Property Name="fatalities" Type="int" />
           <Property Name="dateTime" Type="datetime" />
           <Property Name="culls" Type="int" />
@@ -941,6 +942,7 @@ FROM [dbo].[vw_DeviceDetails] AS [vw_DeviceDetails]</DefiningQuery>
           </Key>
           <Property Name="ID" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
           <Property Name="briolerID" Type="Int32" />
+          <Property Name="cycleId" Type="Int32" />
           <Property Name="fatalities" Type="Int32" />
           <Property Name="dateTime" Type="DateTime" Precision="3" />
           <Property Name="culls" Type="Int32" />
@@ -1636,6 +1638,7 @@ FROM [dbo].[vw_DeviceDetails] AS [vw_DeviceDetails]</DefiningQuery>
                 <ScalarProperty Name="dateTime" ColumnName="dateTime" />
                 <ScalarProperty Name="fatalities" ColumnName="fatalities" />
                 <ScalarProperty Name="briolerID" ColumnName="briolerID" />
+                <ScalarProperty Name="cycleId" ColumnName="cycleId" />
                 <ScalarProperty Name="ID" ColumnName="ID" />
               </MappingFragment>
             </EntityTypeMapping>

--- a/OmniAPI/tbl_BriolerData.cs
+++ b/OmniAPI/tbl_BriolerData.cs
@@ -22,6 +22,7 @@ namespace OmniAPI
         public Nullable<double> weight { get; set; }
         public Nullable<int> eventCullsID { get; set; }
         public Nullable<int> eventMortalitiesID { get; set; }
+        public Nullable<int> cycleId { get; set; }
     
         public virtual tbl_CullsEvent tbl_CullsEvent { get; set; }
         public virtual tbl_MortalitiesEvent tbl_MortalitiesEvent { get; set; }


### PR DESCRIPTION
## Summary
- pass the `cycleId` value when updating existing mortality records
- expose `cycleId` on `tbl_BriolerData` and map it in the data model

## Testing
- `dotnet build OmniAPI.sln` *(fails: command not found)*
- `msbuild OmniAPI.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c828ebe6e883249b3491c6f8ef086c