### PR TITLE
Add cycle-filtered feed water data endpoint

### DIFF
--- a/OmniAPI/Controllers/DashController.cs
+++ b/OmniAPI/Controllers/DashController.cs
@@ -658,6 +658,27 @@ namespace OmniAPI.Controllers
             }
         }
 
+        [Route("getWaterFeedData/{id}/{cycleId}")]
+        [HttpGet]
+        // [Authorize]
+        public List<tbl_FeedWater> getWaterFeedData(int id, int cycleId)
+        {
+            try
+            {
+
+                omnioEntities en = new omnioEntities();
+                en.Configuration.LazyLoadingEnabled = false;
+                List<tbl_FeedWater> FeedWater = en.tbl_FeedWater.Where(x => x.broilerID == id && x.cycleId == cycleId).ToList();
+
+                return FeedWater;
+            }
+            catch (Exception e)
+            {
+                string str = e.ToString();
+                return null;
+            }
+        }
+
 
         [Route("AddUpdateFeedWater")]
         [HttpPost]

--- a/OmniAPI/Omnio.edmx
+++ b/OmniAPI/Omnio.edmx
@@ -267,6 +267,7 @@
           </Key>
           <Property Name="ID" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
           <Property Name="broilerID" Type="int" />
+          <Property Name="cycleId" Type="int" />
           <Property Name="Feed" Type="float" />
           <Property Name="WaterConsumption" Type="float" />
           <Property Name="DateTime" Type="datetime" />
@@ -1089,6 +1090,7 @@ FROM [dbo].[vw_DeviceDetails] AS [vw_DeviceDetails]</DefiningQuery>
           </Key>
           <Property Name="ID" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
           <Property Name="broilerID" Type="Int32" />
+          <Property Name="cycleId" Type="Int32" />
           <Property Name="Feed" Type="Double" />
           <Property Name="WaterConsumption" Type="Double" />
           <Property Name="DateTime" Type="DateTime" Precision="3" />
@@ -1773,6 +1775,7 @@ FROM [dbo].[vw_DeviceDetails] AS [vw_DeviceDetails]</DefiningQuery>
                 <ScalarProperty Name="WaterConsumption" ColumnName="WaterConsumption" />
                 <ScalarProperty Name="Feed" ColumnName="Feed" />
                 <ScalarProperty Name="broilerID" ColumnName="broilerID" />
+                <ScalarProperty Name="cycleId" ColumnName="cycleId" />
                 <ScalarProperty Name="ID" ColumnName="ID" />
               </MappingFragment>
             </EntityTypeMapping>

--- a/OmniAPI/tbl_FeedWater.cs
+++ b/OmniAPI/tbl_FeedWater.cs
@@ -19,5 +19,6 @@ namespace OmniAPI
         public Nullable<double> Feed { get; set; }
         public Nullable<double> WaterConsumption { get; set; }
         public Nullable<System.DateTime> DateTime { get; set; }
+        public Nullable<int> cycleId { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- add a new GET endpoint at `/getWaterFeedData/{id}/{cycleId}` to retrieve feed and water entries for a given cycle
- extend the `tbl_FeedWater` entity and EDMX metadata with a `cycleId` property to support cycle-based filtering

## Testing
- dotnet build OmniAPI.sln *(fails: `dotnet` command not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8522cbd148324ba49a9dbfc60fbd4