### PR TITLE
Add cycle-specific feed retrieval endpoint

### DIFF
--- a/OmniAPI/Controllers/BroilerController.cs
+++ b/OmniAPI/Controllers/BroilerController.cs
@@ -102,7 +102,24 @@ namespace OmniAPI.Controllers
             {
                 omnioEntities en = new omnioEntities();
                 List<tbl_Feed> feed = en.tbl_Feed.Where(x => x.broilerId == id).ToList();
-                               
+
+                return feed;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        [Route("getFeed/{id}/{cycleId}")]
+        [HttpGet]
+        public List<tbl_Feed> getFeed(int id, int cycleId)
+        {
+            try
+            {
+                omnioEntities en = new omnioEntities();
+                List<tbl_Feed> feed = en.tbl_Feed.Where(x => x.broilerId == id && x.cycleId == cycleId).ToList();
+
                 return feed;
             }
             catch


### PR DESCRIPTION
## Summary
- add a new GET endpoint that returns broiler feed data filtered by cycle ID

## Testing
- dotnet build OmniAPI.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d012b440a48324adbc757a938ef0bf