### PR TITLE
Handle partial device limit updates

### DIFF
--- a/OmniAPI/Controllers/DeviceController.cs
+++ b/OmniAPI/Controllers/DeviceController.cs
@@ -19,41 +19,137 @@ namespace OmniAPI.Controllers
 {
     public class DeviceLimitUpdateRequest
     {
-<<<<<<< HEAD
-=======
-        [JsonProperty("deviceDataID")]
-        public long? DeviceDataID { get; set; }
+        private long? _deviceDataID;
+        private double? _highLimit;
+        private double? _lowLimit;
+        private bool? _thresholdEnabled;
+        private string _primaryContact;
+        private string _secondaryContact;
+        private int? _secondaryContactDelay;
+        private bool? _fuzzyLimits;
+        private double? _fuzzyLow;
+        private double? _fuzzyHigh;
 
->>>>>>> origin/codex/add-post-endpoint-for-/updatedevice/devicedataid-xe5ak7
+        public bool DeviceDataIDProvided { get; private set; }
+        public bool HighLimitProvided { get; private set; }
+        public bool LowLimitProvided { get; private set; }
+        public bool ThresholdEnabledProvided { get; private set; }
+        public bool PrimaryContactProvided { get; private set; }
+        public bool SecondaryContactProvided { get; private set; }
+        public bool SecondaryContactDelayProvided { get; private set; }
+        public bool FuzzyLimitsProvided { get; private set; }
+        public bool FuzzyLowProvided { get; private set; }
+        public bool FuzzyHighProvided { get; private set; }
+
+        [JsonProperty("deviceDataID")]
+        public long? DeviceDataID
+        {
+            get => _deviceDataID;
+            set
+            {
+                DeviceDataIDProvided = true;
+                _deviceDataID = value;
+            }
+        }
+
         [JsonProperty("highLimit")]
-        public double? HighLimit { get; set; }
+        public double? HighLimit
+        {
+            get => _highLimit;
+            set
+            {
+                HighLimitProvided = true;
+                _highLimit = value;
+            }
+        }
 
         [JsonProperty("lowLimit")]
-        public double? LowLimit { get; set; }
+        public double? LowLimit
+        {
+            get => _lowLimit;
+            set
+            {
+                LowLimitProvided = true;
+                _lowLimit = value;
+            }
+        }
 
         [JsonProperty("thresholdEnabled")]
-        public bool? ThresholdEnabled { get; set; }
+        public bool? ThresholdEnabled
+        {
+            get => _thresholdEnabled;
+            set
+            {
+                ThresholdEnabledProvided = true;
+                _thresholdEnabled = value;
+            }
+        }
 
         [JsonProperty("primaryContact")]
-        public string PrimaryContact { get; set; }
+        public string PrimaryContact
+        {
+            get => _primaryContact;
+            set
+            {
+                PrimaryContactProvided = true;
+                _primaryContact = value;
+            }
+        }
 
         [JsonProperty("secondaryContact")]
-        public string SecondaryContact { get; set; }
+        public string SecondaryContact
+        {
+            get => _secondaryContact;
+            set
+            {
+                SecondaryContactProvided = true;
+                _secondaryContact = value;
+            }
+        }
 
         [JsonProperty("secondaryContactDelay")]
-        public int? SecondaryContactDelay { get; set; }
+        public int? SecondaryContactDelay
+        {
+            get => _secondaryContactDelay;
+            set
+            {
+                SecondaryContactDelayProvided = true;
+                _secondaryContactDelay = value;
+            }
+        }
 
         [JsonProperty("fuzzyLimits")]
-        public bool? FuzzyLimits { get; set; }
-<<<<<<< HEAD
-=======
+        public bool? FuzzyLimits
+        {
+            get => _fuzzyLimits;
+            set
+            {
+                FuzzyLimitsProvided = true;
+                _fuzzyLimits = value;
+            }
+        }
 
         [JsonProperty("fuzzy_Low")]
-        public double? FuzzyLow { get; set; }
+        public double? FuzzyLow
+        {
+            get => _fuzzyLow;
+            set
+            {
+                FuzzyLowProvided = true;
+                _fuzzyLow = value;
+            }
+        }
 
         [JsonProperty("fuzzy_High")]
-        public double? FuzzyHigh { get; set; }
->>>>>>> origin/codex/add-post-endpoint-for-/updatedevice/devicedataid-xe5ak7
+        public double? FuzzyHigh
+        {
+            get => _fuzzyHigh;
+            set
+            {
+                FuzzyHighProvided = true;
+                _fuzzyHigh = value;
+            }
+        }
     }
 
     [EnableCors(origins: "*", headers: "*", methods: "*")]
@@ -157,54 +253,47 @@ namespace OmniAPI.Controllers
                 return false;
             }
 
-<<<<<<< HEAD
-=======
-            if (limits.DeviceDataID.HasValue && limits.DeviceDataID.Value != deviceDataID)
+            if (limits.DeviceDataIDProvided && limits.DeviceDataID.HasValue && limits.DeviceDataID.Value != deviceDataID)
             {
                 return false;
             }
 
->>>>>>> origin/codex/add-post-endpoint-for-/updatedevice/devicedataid-xe5ak7
             try
             {
                 using (omnioEntities en = new omnioEntities())
                 {
                     const string updateSql = @"UPDATE tbl_DeviceLimits
-<<<<<<< HEAD
-SET HighLimit = @HighLimit,
-    LowLimit = @LowLimit,
-    ThresholdEnabled = @ThresholdEnabled,
-    PrimaryContact = @PrimaryContact,
-    SecondaryContact = @SecondaryContact,
-    SecondaryContactDelay = @SecondaryContactDelay,
-    FuzzyLimits = @FuzzyLimits
-=======
-SET HighLimit = COALESCE(@HighLimit, HighLimit),
-    LowLimit = COALESCE(@LowLimit, LowLimit),
-    ThresholdEnabled = COALESCE(@ThresholdEnabled, ThresholdEnabled),
-    PrimaryContact = COALESCE(@PrimaryContact, PrimaryContact),
-    SecondaryContact = COALESCE(@SecondaryContact, SecondaryContact),
-    SecondaryContactDelay = COALESCE(@SecondaryContactDelay, SecondaryContactDelay),
-    FuzzyLimits = COALESCE(@FuzzyLimits, FuzzyLimits),
-    Fuzzy_Low = COALESCE(@FuzzyLow, Fuzzy_Low),
-    Fuzzy_High = COALESCE(@FuzzyHigh, Fuzzy_High)
->>>>>>> origin/codex/add-post-endpoint-for-/updatedevice/devicedataid-xe5ak7
+SET HighLimit = CASE WHEN @HighLimitProvided = 1 THEN @HighLimit ELSE HighLimit END,
+    LowLimit = CASE WHEN @LowLimitProvided = 1 THEN @LowLimit ELSE LowLimit END,
+    ThresholdEnabled = CASE WHEN @ThresholdEnabledProvided = 1 THEN @ThresholdEnabled ELSE ThresholdEnabled END,
+    PrimaryContact = CASE WHEN @PrimaryContactProvided = 1 THEN @PrimaryContact ELSE PrimaryContact END,
+    SecondaryContact = CASE WHEN @SecondaryContactProvided = 1 THEN @SecondaryContact ELSE SecondaryContact END,
+    SecondaryContactDelay = CASE WHEN @SecondaryContactDelayProvided = 1 THEN @SecondaryContactDelay ELSE SecondaryContactDelay END,
+    FuzzyLimits = CASE WHEN @FuzzyLimitsProvided = 1 THEN @FuzzyLimits ELSE FuzzyLimits END,
+    Fuzzy_Low = CASE WHEN @FuzzyLowProvided = 1 THEN @FuzzyLow ELSE Fuzzy_Low END,
+    Fuzzy_High = CASE WHEN @FuzzyHighProvided = 1 THEN @FuzzyHigh ELSE Fuzzy_High END
 WHERE DeviceDataID = @DeviceDataID";
 
                     SqlParameter[] parameters = new[]
                     {
+                        CreateSqlParameter("@HighLimitProvided", SqlDbType.Bit, limits.HighLimitProvided),
                         CreateSqlParameter("@HighLimit", SqlDbType.Float, limits.HighLimit),
+                        CreateSqlParameter("@LowLimitProvided", SqlDbType.Bit, limits.LowLimitProvided),
                         CreateSqlParameter("@LowLimit", SqlDbType.Float, limits.LowLimit),
+                        CreateSqlParameter("@ThresholdEnabledProvided", SqlDbType.Bit, limits.ThresholdEnabledProvided),
                         CreateSqlParameter("@ThresholdEnabled", SqlDbType.Bit, limits.ThresholdEnabled),
+                        CreateSqlParameter("@PrimaryContactProvided", SqlDbType.Bit, limits.PrimaryContactProvided),
                         CreateSqlParameter("@PrimaryContact", SqlDbType.VarChar, limits.PrimaryContact, 100),
+                        CreateSqlParameter("@SecondaryContactProvided", SqlDbType.Bit, limits.SecondaryContactProvided),
                         CreateSqlParameter("@SecondaryContact", SqlDbType.VarChar, limits.SecondaryContact, 100),
+                        CreateSqlParameter("@SecondaryContactDelayProvided", SqlDbType.Bit, limits.SecondaryContactDelayProvided),
                         CreateSqlParameter("@SecondaryContactDelay", SqlDbType.Int, limits.SecondaryContactDelay),
+                        CreateSqlParameter("@FuzzyLimitsProvided", SqlDbType.Bit, limits.FuzzyLimitsProvided),
                         CreateSqlParameter("@FuzzyLimits", SqlDbType.Bit, limits.FuzzyLimits),
-<<<<<<< HEAD
-=======
+                        CreateSqlParameter("@FuzzyLowProvided", SqlDbType.Bit, limits.FuzzyLowProvided),
                         CreateSqlParameter("@FuzzyLow", SqlDbType.Float, limits.FuzzyLow),
+                        CreateSqlParameter("@FuzzyHighProvided", SqlDbType.Bit, limits.FuzzyHighProvided),
                         CreateSqlParameter("@FuzzyHigh", SqlDbType.Float, limits.FuzzyHigh),
->>>>>>> origin/codex/add-post-endpoint-for-/updatedevice/devicedataid-xe5ak7
                         CreateSqlParameter("@DeviceDataID", SqlDbType.BigInt, deviceDataID)
                     };
 


### PR DESCRIPTION
## Summary
- track which device limit fields were supplied in the update payload
- use CASE expressions so only supplied values overwrite existing device limits
- pass the new provided flags alongside the existing SQL parameters

## Testing
- not run (environment lacks dotnet CLI)


------
https://chatgpt.com/codex/tasks/task_e_68de722b5e308324a7da4dd53b8b86bb