### PR TITLE
Revert partial device limit null handling

### DIFF
--- a/OmniAPI/Controllers/DeviceController.cs
+++ b/OmniAPI/Controllers/DeviceController.cs
@@ -19,12 +19,9 @@ namespace OmniAPI.Controllers
 {
     public class DeviceLimitUpdateRequest
     {
-<<<<<<< HEAD
-=======
         [JsonProperty("deviceDataID")]
         public long? DeviceDataID { get; set; }
 
->>>>>>> origin/codex/add-post-endpoint-for-/updatedevice/devicedataid-xe5ak7
         [JsonProperty("highLimit")]
         public double? HighLimit { get; set; }
 
@@ -45,15 +42,12 @@ namespace OmniAPI.Controllers
 
         [JsonProperty("fuzzyLimits")]
         public bool? FuzzyLimits { get; set; }
-<<<<<<< HEAD
-=======
 
         [JsonProperty("fuzzy_Low")]
         public double? FuzzyLow { get; set; }
 
         [JsonProperty("fuzzy_High")]
         public double? FuzzyHigh { get; set; }
->>>>>>> origin/codex/add-post-endpoint-for-/updatedevice/devicedataid-xe5ak7
     }
 
     [EnableCors(origins: "*", headers: "*", methods: "*")]
@@ -157,28 +151,16 @@ namespace OmniAPI.Controllers
                 return false;
             }
 
-<<<<<<< HEAD
-=======
             if (limits.DeviceDataID.HasValue && limits.DeviceDataID.Value != deviceDataID)
             {
                 return false;
             }
 
->>>>>>> origin/codex/add-post-endpoint-for-/updatedevice/devicedataid-xe5ak7
             try
             {
                 using (omnioEntities en = new omnioEntities())
                 {
                     const string updateSql = @"UPDATE tbl_DeviceLimits
-<<<<<<< HEAD
-SET HighLimit = @HighLimit,
-    LowLimit = @LowLimit,
-    ThresholdEnabled = @ThresholdEnabled,
-    PrimaryContact = @PrimaryContact,
-    SecondaryContact = @SecondaryContact,
-    SecondaryContactDelay = @SecondaryContactDelay,
-    FuzzyLimits = @FuzzyLimits
-=======
 SET HighLimit = COALESCE(@HighLimit, HighLimit),
     LowLimit = COALESCE(@LowLimit, LowLimit),
     ThresholdEnabled = COALESCE(@ThresholdEnabled, ThresholdEnabled),
@@ -188,7 +170,6 @@ SET HighLimit = COALESCE(@HighLimit, HighLimit),
     FuzzyLimits = COALESCE(@FuzzyLimits, FuzzyLimits),
     Fuzzy_Low = COALESCE(@FuzzyLow, Fuzzy_Low),
     Fuzzy_High = COALESCE(@FuzzyHigh, Fuzzy_High)
->>>>>>> origin/codex/add-post-endpoint-for-/updatedevice/devicedataid-xe5ak7
 WHERE DeviceDataID = @DeviceDataID";
 
                     SqlParameter[] parameters = new[]
@@ -200,11 +181,8 @@ WHERE DeviceDataID = @DeviceDataID";
                         CreateSqlParameter("@SecondaryContact", SqlDbType.VarChar, limits.SecondaryContact, 100),
                         CreateSqlParameter("@SecondaryContactDelay", SqlDbType.Int, limits.SecondaryContactDelay),
                         CreateSqlParameter("@FuzzyLimits", SqlDbType.Bit, limits.FuzzyLimits),
-<<<<<<< HEAD
-=======
                         CreateSqlParameter("@FuzzyLow", SqlDbType.Float, limits.FuzzyLow),
                         CreateSqlParameter("@FuzzyHigh", SqlDbType.Float, limits.FuzzyHigh),
->>>>>>> origin/codex/add-post-endpoint-for-/updatedevice/devicedataid-xe5ak7
                         CreateSqlParameter("@DeviceDataID", SqlDbType.BigInt, deviceDataID)
                     };
 


### PR DESCRIPTION
## Summary
- remove the DeviceLimitUpdateRequest backing fields and presence flags
- restore the COALESCE-based SQL update for partial device limit updates

## Testing
- not run (dotnet CLI unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68de722b5e308324a7da4dd53b8b86bb