### PR TITLE
Restore nullable device limit updates with presence tracking

### DIFF
--- a/OmniAPI/Controllers/DeviceController.cs
+++ b/OmniAPI/Controllers/DeviceController.cs
@@ -19,41 +19,156 @@ namespace OmniAPI.Controllers
 {
     public class DeviceLimitUpdateRequest
     {
-<<<<<<< HEAD
-=======
-        [JsonProperty("deviceDataID")]
-        public long? DeviceDataID { get; set; }
+        private long? _deviceDataID;
+        private double? _highLimit;
+        private double? _lowLimit;
+        private bool? _thresholdEnabled;
+        private string _primaryContact;
+        private string _secondaryContact;
+        private int? _secondaryContactDelay;
+        private bool? _fuzzyLimits;
+        private double? _fuzzyLow;
+        private double? _fuzzyHigh;
 
->>>>>>> origin/codex/add-post-endpoint-for-/updatedevice/devicedataid-xe5ak7
+        [JsonProperty("deviceDataID")]
+        public long? DeviceDataID
+        {
+            get => _deviceDataID;
+            set
+            {
+                _deviceDataID = value;
+                DeviceDataIDProvided = true;
+            }
+        }
+
+        [JsonIgnore]
+        public bool DeviceDataIDProvided { get; private set; }
+
         [JsonProperty("highLimit")]
-        public double? HighLimit { get; set; }
+        public double? HighLimit
+        {
+            get => _highLimit;
+            set
+            {
+                _highLimit = value;
+                HighLimitProvided = true;
+            }
+        }
+
+        [JsonIgnore]
+        public bool HighLimitProvided { get; private set; }
 
         [JsonProperty("lowLimit")]
-        public double? LowLimit { get; set; }
+        public double? LowLimit
+        {
+            get => _lowLimit;
+            set
+            {
+                _lowLimit = value;
+                LowLimitProvided = true;
+            }
+        }
+
+        [JsonIgnore]
+        public bool LowLimitProvided { get; private set; }
 
         [JsonProperty("thresholdEnabled")]
-        public bool? ThresholdEnabled { get; set; }
+        public bool? ThresholdEnabled
+        {
+            get => _thresholdEnabled;
+            set
+            {
+                _thresholdEnabled = value;
+                ThresholdEnabledProvided = true;
+            }
+        }
+
+        [JsonIgnore]
+        public bool ThresholdEnabledProvided { get; private set; }
 
         [JsonProperty("primaryContact")]
-        public string PrimaryContact { get; set; }
+        public string PrimaryContact
+        {
+            get => _primaryContact;
+            set
+            {
+                _primaryContact = value;
+                PrimaryContactProvided = true;
+            }
+        }
+
+        [JsonIgnore]
+        public bool PrimaryContactProvided { get; private set; }
 
         [JsonProperty("secondaryContact")]
-        public string SecondaryContact { get; set; }
+        public string SecondaryContact
+        {
+            get => _secondaryContact;
+            set
+            {
+                _secondaryContact = value;
+                SecondaryContactProvided = true;
+            }
+        }
+
+        [JsonIgnore]
+        public bool SecondaryContactProvided { get; private set; }
 
         [JsonProperty("secondaryContactDelay")]
-        public int? SecondaryContactDelay { get; set; }
+        public int? SecondaryContactDelay
+        {
+            get => _secondaryContactDelay;
+            set
+            {
+                _secondaryContactDelay = value;
+                SecondaryContactDelayProvided = true;
+            }
+        }
+
+        [JsonIgnore]
+        public bool SecondaryContactDelayProvided { get; private set; }
 
         [JsonProperty("fuzzyLimits")]
-        public bool? FuzzyLimits { get; set; }
-<<<<<<< HEAD
-=======
+        public bool? FuzzyLimits
+        {
+            get => _fuzzyLimits;
+            set
+            {
+                _fuzzyLimits = value;
+                FuzzyLimitsProvided = true;
+            }
+        }
+
+        [JsonIgnore]
+        public bool FuzzyLimitsProvided { get; private set; }
 
         [JsonProperty("fuzzy_Low")]
-        public double? FuzzyLow { get; set; }
+        public double? FuzzyLow
+        {
+            get => _fuzzyLow;
+            set
+            {
+                _fuzzyLow = value;
+                FuzzyLowProvided = true;
+            }
+        }
+
+        [JsonIgnore]
+        public bool FuzzyLowProvided { get; private set; }
 
         [JsonProperty("fuzzy_High")]
-        public double? FuzzyHigh { get; set; }
->>>>>>> origin/codex/add-post-endpoint-for-/updatedevice/devicedataid-xe5ak7
+        public double? FuzzyHigh
+        {
+            get => _fuzzyHigh;
+            set
+            {
+                _fuzzyHigh = value;
+                FuzzyHighProvided = true;
+            }
+        }
+
+        [JsonIgnore]
+        public bool FuzzyHighProvided { get; private set; }
     }
 
     [EnableCors(origins: "*", headers: "*", methods: "*")]
@@ -157,54 +272,50 @@ namespace OmniAPI.Controllers
                 return false;
             }
 
-<<<<<<< HEAD
-=======
-            if (limits.DeviceDataID.HasValue && limits.DeviceDataID.Value != deviceDataID)
+            if (limits.DeviceDataIDProvided)
             {
-                return false;
+                if (!limits.DeviceDataID.HasValue || limits.DeviceDataID.Value != deviceDataID)
+                {
+                    return false;
+                }
             }
 
->>>>>>> origin/codex/add-post-endpoint-for-/updatedevice/devicedataid-xe5ak7
             try
             {
                 using (omnioEntities en = new omnioEntities())
                 {
                     const string updateSql = @"UPDATE tbl_DeviceLimits
-<<<<<<< HEAD
-SET HighLimit = @HighLimit,
-    LowLimit = @LowLimit,
-    ThresholdEnabled = @ThresholdEnabled,
-    PrimaryContact = @PrimaryContact,
-    SecondaryContact = @SecondaryContact,
-    SecondaryContactDelay = @SecondaryContactDelay,
-    FuzzyLimits = @FuzzyLimits
-=======
-SET HighLimit = COALESCE(@HighLimit, HighLimit),
-    LowLimit = COALESCE(@LowLimit, LowLimit),
-    ThresholdEnabled = COALESCE(@ThresholdEnabled, ThresholdEnabled),
-    PrimaryContact = COALESCE(@PrimaryContact, PrimaryContact),
-    SecondaryContact = COALESCE(@SecondaryContact, SecondaryContact),
-    SecondaryContactDelay = COALESCE(@SecondaryContactDelay, SecondaryContactDelay),
-    FuzzyLimits = COALESCE(@FuzzyLimits, FuzzyLimits),
-    Fuzzy_Low = COALESCE(@FuzzyLow, Fuzzy_Low),
-    Fuzzy_High = COALESCE(@FuzzyHigh, Fuzzy_High)
->>>>>>> origin/codex/add-post-endpoint-for-/updatedevice/devicedataid-xe5ak7
+SET HighLimit = CASE WHEN @HighLimitProvided = 1 THEN @HighLimit ELSE HighLimit END,
+    LowLimit = CASE WHEN @LowLimitProvided = 1 THEN @LowLimit ELSE LowLimit END,
+    ThresholdEnabled = CASE WHEN @ThresholdEnabledProvided = 1 THEN @ThresholdEnabled ELSE ThresholdEnabled END,
+    PrimaryContact = CASE WHEN @PrimaryContactProvided = 1 THEN @PrimaryContact ELSE PrimaryContact END,
+    SecondaryContact = CASE WHEN @SecondaryContactProvided = 1 THEN @SecondaryContact ELSE SecondaryContact END,
+    SecondaryContactDelay = CASE WHEN @SecondaryContactDelayProvided = 1 THEN @SecondaryContactDelay ELSE SecondaryContactDelay END,
+    FuzzyLimits = CASE WHEN @FuzzyLimitsProvided = 1 THEN @FuzzyLimits ELSE FuzzyLimits END,
+    Fuzzy_Low = CASE WHEN @FuzzyLowProvided = 1 THEN @FuzzyLow ELSE Fuzzy_Low END,
+    Fuzzy_High = CASE WHEN @FuzzyHighProvided = 1 THEN @FuzzyHigh ELSE Fuzzy_High END
 WHERE DeviceDataID = @DeviceDataID";
 
                     SqlParameter[] parameters = new[]
                     {
                         CreateSqlParameter("@HighLimit", SqlDbType.Float, limits.HighLimit),
+                        CreateSqlParameter("@HighLimitProvided", SqlDbType.Bit, limits.HighLimitProvided),
                         CreateSqlParameter("@LowLimit", SqlDbType.Float, limits.LowLimit),
+                        CreateSqlParameter("@LowLimitProvided", SqlDbType.Bit, limits.LowLimitProvided),
                         CreateSqlParameter("@ThresholdEnabled", SqlDbType.Bit, limits.ThresholdEnabled),
+                        CreateSqlParameter("@ThresholdEnabledProvided", SqlDbType.Bit, limits.ThresholdEnabledProvided),
                         CreateSqlParameter("@PrimaryContact", SqlDbType.VarChar, limits.PrimaryContact, 100),
+                        CreateSqlParameter("@PrimaryContactProvided", SqlDbType.Bit, limits.PrimaryContactProvided),
                         CreateSqlParameter("@SecondaryContact", SqlDbType.VarChar, limits.SecondaryContact, 100),
+                        CreateSqlParameter("@SecondaryContactProvided", SqlDbType.Bit, limits.SecondaryContactProvided),
                         CreateSqlParameter("@SecondaryContactDelay", SqlDbType.Int, limits.SecondaryContactDelay),
+                        CreateSqlParameter("@SecondaryContactDelayProvided", SqlDbType.Bit, limits.SecondaryContactDelayProvided),
                         CreateSqlParameter("@FuzzyLimits", SqlDbType.Bit, limits.FuzzyLimits),
-<<<<<<< HEAD
-=======
+                        CreateSqlParameter("@FuzzyLimitsProvided", SqlDbType.Bit, limits.FuzzyLimitsProvided),
                         CreateSqlParameter("@FuzzyLow", SqlDbType.Float, limits.FuzzyLow),
+                        CreateSqlParameter("@FuzzyLowProvided", SqlDbType.Bit, limits.FuzzyLowProvided),
                         CreateSqlParameter("@FuzzyHigh", SqlDbType.Float, limits.FuzzyHigh),
->>>>>>> origin/codex/add-post-endpoint-for-/updatedevice/devicedataid-xe5ak7
+                        CreateSqlParameter("@FuzzyHighProvided", SqlDbType.Bit, limits.FuzzyHighProvided),
                         CreateSqlParameter("@DeviceDataID", SqlDbType.BigInt, deviceDataID)
                     };
 


### PR DESCRIPTION
## Summary
- track which JSON properties were supplied by adding backing fields and `...Provided` flags to `DeviceLimitUpdateRequest`
- update `/updateDevice/{deviceDataID}` to gate column updates on provided flags so explicit `null` values overwrite existing data
- validate a provided `deviceDataID` matches the route value before running the update statement

## Testing
- not run (dotnet CLI unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68de722b5e308324a7da4dd53b8b86bb