### PR TITLE
Convert Act notification broiler ID to string

### DIFF
--- a/OmniAPI/Controllers/BroilerController.cs
+++ b/OmniAPI/Controllers/BroilerController.cs
@@ -169,7 +169,7 @@ namespace OmniAPI.Controllers
                 using (omnioEntities en = new omnioEntities())
                 {
                     const string query =
-                        "SELECT Id, Act, Completed, ConditionsNotMet, NotCompleted, PrimaryContact, SecondaryContact, Delay, BroilerID FROM dbo.tbl_ActNotifications WHERE BroilerID = @broilerId";
+                        "SELECT Id, Act, Completed, ConditionsNotMet, NotCompleted, PrimaryContact, SecondaryContact, Delay, CAST(BroilerID AS NVARCHAR(50)) AS BroilerID FROM dbo.tbl_ActNotifications WHERE BroilerID = @broilerId";
 
                     SqlParameter broilerIdParameter = new SqlParameter("@broilerId", id);
                     List<ActNotificationDto> notifications = en.Database
@@ -179,7 +179,7 @@ namespace OmniAPI.Controllers
                     if (!notifications.Any())
                     {
                         const string fallbackQuery =
-                            "SELECT Id, Act, Completed, ConditionsNotMet, NotCompleted, PrimaryContact, SecondaryContact, Delay, TRY_CAST(BroilerID AS INT) AS BroilerID FROM dbo.tbl_ActNotifications WHERE CAST(BroilerID AS NVARCHAR(50)) = @broilerId";
+                            "SELECT Id, Act, Completed, ConditionsNotMet, NotCompleted, PrimaryContact, SecondaryContact, Delay, CAST(BroilerID AS NVARCHAR(50)) AS BroilerID FROM dbo.tbl_ActNotifications WHERE CAST(BroilerID AS NVARCHAR(50)) = @broilerId";
                         SqlParameter fallbackParameter = new SqlParameter("@broilerId", id.ToString());
                         notifications = en.Database.SqlQuery<ActNotificationDto>(fallbackQuery, fallbackParameter).ToList();
                     }
@@ -202,7 +202,7 @@ namespace OmniAPI.Controllers
                 using (omnioEntities en = new omnioEntities())
                 {
                     const string query =
-                        "SELECT Id, Act, Completed, ConditionsNotMet, NotCompleted, PrimaryContact, SecondaryContact, Delay, BroilerID FROM dbo.tbl_ActNotifications";
+                        "SELECT Id, Act, Completed, ConditionsNotMet, NotCompleted, PrimaryContact, SecondaryContact, Delay, CAST(BroilerID AS NVARCHAR(50)) AS BroilerID FROM dbo.tbl_ActNotifications";
 
                     return en.Database
                         .SqlQuery<ActNotificationDto>(query)

--- a/OmniAPI/Models/ActNotificationDto.cs
+++ b/OmniAPI/Models/ActNotificationDto.cs
@@ -10,6 +10,6 @@ namespace OmniAPI.Models
         public string PrimaryContact { get; set; }
         public string SecondaryContact { get; set; }
         public int Delay { get; set; }
-        public int BroilerID { get; set; }
+        public string BroilerID { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- return broiler IDs as strings in Act notification responses
- cast Act notification queries to NVARCHAR so string values are always returned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e53ca06c2c8324a0713261fc6b7aac